### PR TITLE
Copy ボタンのスタイルと位置を調整

### DIFF
--- a/packages/web/app/routes/_index/route.tsx
+++ b/packages/web/app/routes/_index/route.tsx
@@ -52,22 +52,11 @@ export default function Index() {
             </Group>
           </Stack>
           <Paper p="md" style={{ position: "relative" }}>
-            <div style={{ position: "absolute", right: "0.5rem" }}>
+            <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
               <CopyButton value={d.content}>
                 {({ copied, copy }) => (
-                  <ActionIcon
-                    variant="default"
-                    style={{
-                      width: rem(32),
-                      height: rem(32),
-                    }}
-                    onClick={copy}
-                  >
-                    {copied ? (
-                      <IconCheckBoxOutline color="#000" />
-                    ) : (
-                      <IconCopyOutline color="#000" />
-                    )}
+                  <ActionIcon variant="subtle" color="dark" onClick={copy}>
+                    {copied ? <IconCheckBoxOutline /> : <IconCopyOutline />}
                   </ActionIcon>
                 )}
               </CopyButton>


### PR DESCRIPTION
色の主張を抑えめにして、テキストに被らないようにする。

PC
<img width="618" alt="Screenshot 2024-10-03 at 23 53 53" src="https://github.com/user-attachments/assets/365a2659-f3ca-4308-9cb5-4dd41c51efb9">

スマホ
<img width="441" alt="Screenshot 2024-10-03 at 23 55 09" src="https://github.com/user-attachments/assets/4093fbf9-0ea6-4a1f-95b1-0302a38c2cc9">
