### PR TITLE
meta情報の表示

### DIFF
--- a/packages/web/app/routes/_index/route.tsx
+++ b/packages/web/app/routes/_index/route.tsx
@@ -1,11 +1,12 @@
 import {
   ActionIcon,
-  Badge,
+  Avatar,
   Card,
   CopyButton,
   Group,
   Paper,
   Stack,
+  Text,
   Title,
   rem,
 } from "@mantine/core";
@@ -14,10 +15,9 @@ import { useLoaderData } from "@remix-run/react";
 import Markdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
-import { type IndexLoader, indexLoader } from "./loader";
-
 import IconCheckBoxOutline from "~icons/material-symbols/check-rounded";
 import IconCopyOutline from "~icons/material-symbols/content-copy-outline-rounded";
+import { type IndexLoader, indexLoader } from "./loader";
 
 export const loader = indexLoader;
 export const meta: MetaFunction = () => {
@@ -40,31 +40,44 @@ export default function Index() {
           radius="md"
           withBorder
         >
-          <Stack mb="lg">
+          <Card.Section p="md" component={Stack}>
             <Title order={2} size="h2">
-              {d.title}
+              {d.title}{" "}
+              <Text c="dimmed" size="lg" span>
+                #{d.id}
+              </Text>
             </Title>
-            <Group gap="xs">
-              <Badge color="pink">#{d.id}</Badge>
-              <Badge color="blue">{d.senpan}</Badge>
-              <Badge color="green">{d.at}</Badge>
-              <Badge color="cyan">{d.date}</Badge>
+          </Card.Section>
+          <Card.Section>
+            <Paper p="md" style={{ position: "relative" }}>
+              <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
+                <CopyButton value={d.content}>
+                  {({ copied, copy }) => (
+                    <ActionIcon variant="subtle" color="dark" onClick={copy}>
+                      {copied ? <IconCheckBoxOutline /> : <IconCopyOutline />}
+                    </ActionIcon>
+                  )}
+                </CopyButton>
+              </div>
+              <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
+                {d.content}
+              </Markdown>
+            </Paper>
+          </Card.Section>
+          <Card.Section p="md">
+            <Group gap="sm" align="center">
+              <Avatar
+                src={`https://avatars.githubusercontent.com/${d.senpan}`}
+                radius="sm"
+              />
+              <Stack gap="0">
+                <Text fw={600}>{d.senpan}</Text>
+                <Text size="sm" c="dimmed">
+                  {d.date} at {d.at}
+                </Text>
+              </Stack>
             </Group>
-          </Stack>
-          <Paper p="md" style={{ position: "relative" }}>
-            <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
-              <CopyButton value={d.content}>
-                {({ copied, copy }) => (
-                  <ActionIcon variant="subtle" color="dark" onClick={copy}>
-                    {copied ? <IconCheckBoxOutline /> : <IconCopyOutline />}
-                  </ActionIcon>
-                )}
-              </CopyButton>
-            </div>
-            <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
-              {d.content}
-            </Markdown>
-          </Paper>
+          </Card.Section>
         </Card>
       ))}
     </Stack>

--- a/packages/web/app/routes/_index/route.tsx
+++ b/packages/web/app/routes/_index/route.tsx
@@ -3,6 +3,7 @@ import {
   Avatar,
   Card,
   CopyButton,
+  Divider,
   Group,
   Paper,
   Stack,
@@ -64,6 +65,18 @@ export default function Index() {
               </Markdown>
             </Paper>
           </Card.Section>
+          {d.meta && (
+            <>
+              <Card.Section px="md">
+                <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
+                  {d.meta}
+                </Markdown>
+              </Card.Section>
+              <Card.Section>
+                <Divider />
+              </Card.Section>
+            </>
+          )}
           <Card.Section p="md">
             <Group gap="sm" align="center">
               <Avatar


### PR DESCRIPTION
Close #46

メタ情報の表示にあたり、情報の整理を行いました。

<img width="700" alt="Screenshot 2024-10-04 at 17 59 07" src="https://github.com/user-attachments/assets/bbc74784-ace4-4645-ae27-be027cdde9dc">
