### PR TITLE
単体の  Awesome Yasunori を表示するページを作成

### DIFF
--- a/packages/web/app/components/awesome-yasunori-card/index.tsx
+++ b/packages/web/app/components/awesome-yasunori-card/index.tsx
@@ -57,7 +57,9 @@ export function AwesomeYasunoriCard({
       <Card.Section>
         <Paper p="md" style={{ position: "relative" }} radius={0}>
           <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
-            <CopyButton value={content}>
+            <CopyButton
+              value={`${content}\nhttps://awesome.yasunori.dev/entries/${id}`}
+            >
               {({ copied, copy }) => (
                 <ActionIcon variant="subtle" color="dark" onClick={copy}>
                   {copied ? <IconrCopyCheckFilled /> : <IconCopy />}

--- a/packages/web/app/components/awesome-yasunori-card/index.tsx
+++ b/packages/web/app/components/awesome-yasunori-card/index.tsx
@@ -46,7 +46,7 @@ export function AwesomeYasunoriCard({
         </Title>
       </Card.Section>
       <Card.Section>
-        <Paper p="md" style={{ position: "relative" }}>
+        <Paper p="md" style={{ position: "relative" }} radius={0}>
           <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
             <CopyButton value={content}>
               {({ copied, copy }) => (

--- a/packages/web/app/components/awesome-yasunori-card/index.tsx
+++ b/packages/web/app/components/awesome-yasunori-card/index.tsx
@@ -1,0 +1,92 @@
+import {
+  ActionIcon,
+  Avatar,
+  Card,
+  type CardProps,
+  CopyButton,
+  Divider,
+  Group,
+  Paper,
+  Stack,
+  Text,
+  Title,
+  rem,
+} from "@mantine/core";
+import type { SerializeFrom } from "@remix-run/cloudflare";
+import Markdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
+import remarkGfm from "remark-gfm";
+import IconCopy from "~icons/tabler/copy";
+import IconrCopyCheckFilled from "~icons/tabler/copy-check-filled";
+import type { IndexLoader } from "../../routes/_index/loader";
+
+interface Props extends CardProps {
+  entry: SerializeFrom<IndexLoader>[number];
+}
+
+export function AwesomeYasunoriCard({
+  entry: { id, title, date, at, senpan, content, meta },
+  ...cardProps
+}: Props) {
+  return (
+    <Card
+      id={`${id}`}
+      shadow="sm"
+      padding="lg"
+      radius="md"
+      withBorder
+      {...cardProps}
+    >
+      <Card.Section p="md" component={Stack}>
+        <Title order={2} size="h2">
+          {title}{" "}
+          <Text c="dimmed" size="lg" span>
+            #{id}
+          </Text>
+        </Title>
+      </Card.Section>
+      <Card.Section>
+        <Paper p="md" style={{ position: "relative" }}>
+          <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
+            <CopyButton value={content}>
+              {({ copied, copy }) => (
+                <ActionIcon variant="subtle" color="dark" onClick={copy}>
+                  {copied ? <IconrCopyCheckFilled /> : <IconCopy />}
+                </ActionIcon>
+              )}
+            </CopyButton>
+          </div>
+          <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
+            {content}
+          </Markdown>
+        </Paper>
+      </Card.Section>
+      {meta && (
+        <>
+          <Card.Section px="md">
+            <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
+              {meta}
+            </Markdown>
+          </Card.Section>
+          <Card.Section>
+            <Divider />
+          </Card.Section>
+        </>
+      )}
+      <Card.Section p="md">
+        <Group gap="sm" align="center">
+          <Avatar
+            src={`https://avatars.githubusercontent.com/${senpan}`}
+            radius="sm"
+          />
+          <Stack gap="0">
+            <Text fw={600}>{senpan}</Text>
+            <Text size="sm" c="dimmed">
+              {date} at {at}
+            </Text>
+          </Stack>
+        </Group>
+      </Card.Section>
+    </Card>
+  );
+}

--- a/packages/web/app/components/awesome-yasunori-card/index.tsx
+++ b/packages/web/app/components/awesome-yasunori-card/index.tsx
@@ -1,6 +1,7 @@
 import {
   ActionIcon,
   Avatar,
+  Button,
   Card,
   type CardProps,
   CopyButton,
@@ -13,6 +14,7 @@ import {
   rem,
 } from "@mantine/core";
 import type { SerializeFrom } from "@remix-run/cloudflare";
+import { useNavigate } from "@remix-run/react";
 import Markdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
@@ -28,6 +30,7 @@ export function AwesomeYasunoriCard({
   entry: { id, title, date, at, senpan, content, meta },
   ...cardProps
 }: Props) {
+  const navigate = useNavigate();
   return (
     <Card
       id={`${id}`}
@@ -40,9 +43,15 @@ export function AwesomeYasunoriCard({
       <Card.Section p="md" component={Stack}>
         <Title order={2} size="h2">
           {title}{" "}
-          <Text c="dimmed" size="lg" span>
-            #{id}
-          </Text>
+          <Button
+            variant="transparent"
+            size="xs"
+            onClick={() => navigate(`/entries/${id}`)}
+          >
+            <Text c="dimmed" size="lg" span>
+              #{id}
+            </Text>
+          </Button>
         </Title>
       </Card.Section>
       <Card.Section>

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -43,7 +43,7 @@ export const links: LinksFunction = () => [
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<IndexLoader>("routes/_index");
-  const isShowNavbar = !!data;
+  const isIndexView = !!data;
   const isMobile = useMediaQuery(`(max-width: ${em(767)})`);
   const pinned = useHeadroom({ fixedAt: 120 });
   const [opened, { toggle, close }] = useDisclosure();
@@ -60,9 +60,11 @@ export function Layout({ children }: { children: React.ReactNode }) {
       <body>
         <MantineProvider forceColorScheme="dark">
           <AppShell
-            header={{ height: 60, collapsed: !pinned }}
+            header={
+              isIndexView ? { height: 60, collapsed: !pinned } : undefined
+            }
             navbar={
-              isShowNavbar
+              isIndexView
                 ? {
                     width: 300,
                     breakpoint: "sm",
@@ -72,76 +74,84 @@ export function Layout({ children }: { children: React.ReactNode }) {
             }
             padding="md"
           >
-            <AppShell.Header p="md">
-              <Group align="center" justify="space-between">
-                <Group gap="sm">
-                  <Burger
-                    opened={opened}
-                    onClick={toggle}
-                    hiddenFrom="sm"
-                    size="sm"
-                  />
-                  <Title
-                    order={1}
-                    size="h2"
-                    style={{ fontFamily: "'Yellowtail', cursive" }}
-                  >
-                    Awesome Yasunori
-                  </Title>
-                </Group>
-                <Group gap={rem(8)}>
-                  <ActionIcon
-                    component="a"
-                    aria-label="rss feed"
-                    href="/feed.xml"
-                    target="_blank"
-                    variant="transparent"
-                    size="sm"
-                    color="--mantine-color-white"
-                  >
-                    <IconRSS />
-                  </ActionIcon>
-                  <ActionIcon
-                    component="a"
-                    aria-label="GitHub Repository"
-                    href="https://github.com/times-yasunori/awesome-yasunori"
-                    target="_blank"
-                    variant="transparent"
-                    size="sm"
-                    color="--mantine-color-white"
-                  >
-                    <IconGitHubLogo />
-                  </ActionIcon>
-                </Group>
-              </Group>
-            </AppShell.Header>
-            {isShowNavbar && (
-              <AppShell.Navbar p="md">
-                <AppShell.Section grow component={ScrollArea}>
-                  {data?.map((d) => (
-                    <NavLink
-                      key={d.id}
-                      onClick={() => {
-                        navigate(`#${d.id}`, { replace: true });
-                        // モバイルのときは移動後にサイドバーを閉じる
-                        if (isMobile) {
-                          close();
+            {isIndexView && (
+              <>
+                <AppShell.Header p="md">
+                  <Group align="center" justify="space-between">
+                    <Group gap="sm">
+                      <Burger
+                        opened={opened}
+                        onClick={toggle}
+                        hiddenFrom="sm"
+                        size="sm"
+                      />
+                      <Title
+                        order={1}
+                        size="h2"
+                        style={{ fontFamily: "'Yellowtail', cursive" }}
+                      >
+                        Awesome Yasunori
+                      </Title>
+                    </Group>
+                    <Group gap={rem(8)}>
+                      <ActionIcon
+                        component="a"
+                        aria-label="rss feed"
+                        href="/feed.xml"
+                        target="_blank"
+                        variant="transparent"
+                        size="sm"
+                        color="--mantine-color-white"
+                      >
+                        <IconRSS />
+                      </ActionIcon>
+                      <ActionIcon
+                        component="a"
+                        aria-label="GitHub Repository"
+                        href="https://github.com/times-yasunori/awesome-yasunori"
+                        target="_blank"
+                        variant="transparent"
+                        size="sm"
+                        color="--mantine-color-white"
+                      >
+                        <IconGitHubLogo />
+                      </ActionIcon>
+                    </Group>
+                  </Group>
+                </AppShell.Header>
+                <AppShell.Navbar p="md">
+                  <AppShell.Section grow component={ScrollArea}>
+                    {data?.map((d) => (
+                      <NavLink
+                        key={d.id}
+                        onClick={() => {
+                          navigate(`#${d.id}`, { replace: true });
+                          // モバイルのときは移動後にサイドバーを閉じる
+                          if (isMobile) {
+                            close();
+                          }
+                        }}
+                        label={
+                          <Group gap="xs">
+                            <Text>{`${d.title}`}</Text>
+                            <Text size="xs" c="dimmed">
+                              {`#${d.id}`}
+                            </Text>
+                          </Group>
                         }
-                      }}
-                      label={
-                        <Group gap="xs">
-                          <Text>{`${d.title}`}</Text>
-                          <Text size="xs" c="dimmed">
-                            {`#${d.id}`}
-                          </Text>
-                        </Group>
-                      }
-                    />
-                  ))}
-                </AppShell.Section>
-              </AppShell.Navbar>
+                      />
+                    ))}
+                  </AppShell.Section>
+                </AppShell.Navbar>
+              </>
             )}
-            <AppShell.Main pt={`calc(${rem(60)} + var(--mantine-spacing-md))`}>
+            <AppShell.Main
+              pt={
+                isIndexView
+                  ? `calc(${rem(60)} + var(--mantine-spacing-md))`
+                  : undefined
+              }
+            >
               {children}
             </AppShell.Main>
           </AppShell>

--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -43,6 +43,7 @@ export const links: LinksFunction = () => [
 
 export function Layout({ children }: { children: React.ReactNode }) {
   const data = useRouteLoaderData<IndexLoader>("routes/_index");
+  const isShowNavbar = !!data;
   const isMobile = useMediaQuery(`(max-width: ${em(767)})`);
   const pinned = useHeadroom({ fixedAt: 120 });
   const [opened, { toggle, close }] = useDisclosure();
@@ -60,11 +61,15 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <MantineProvider forceColorScheme="dark">
           <AppShell
             header={{ height: 60, collapsed: !pinned }}
-            navbar={{
-              width: 300,
-              breakpoint: "sm",
-              collapsed: { mobile: !opened },
-            }}
+            navbar={
+              isShowNavbar
+                ? {
+                    width: 300,
+                    breakpoint: "sm",
+                    collapsed: { mobile: !opened },
+                  }
+                : undefined
+            }
             padding="md"
           >
             <AppShell.Header p="md">
@@ -110,30 +115,32 @@ export function Layout({ children }: { children: React.ReactNode }) {
                 </Group>
               </Group>
             </AppShell.Header>
-            <AppShell.Navbar p="md">
-              <AppShell.Section grow component={ScrollArea}>
-                {data?.map((d) => (
-                  <NavLink
-                    key={d.id}
-                    onClick={() => {
-                      navigate(`#${d.id}`, { replace: true });
-                      // モバイルのときは移動後にサイドバーを閉じる
-                      if (isMobile) {
-                        close();
+            {isShowNavbar && (
+              <AppShell.Navbar p="md">
+                <AppShell.Section grow component={ScrollArea}>
+                  {data?.map((d) => (
+                    <NavLink
+                      key={d.id}
+                      onClick={() => {
+                        navigate(`#${d.id}`, { replace: true });
+                        // モバイルのときは移動後にサイドバーを閉じる
+                        if (isMobile) {
+                          close();
+                        }
+                      }}
+                      label={
+                        <Group gap="xs">
+                          <Text>{`${d.title}`}</Text>
+                          <Text size="xs" c="dimmed">
+                            {`#${d.id}`}
+                          </Text>
+                        </Group>
                       }
-                    }}
-                    label={
-                      <Group gap="xs">
-                        <Text>{`${d.title}`}</Text>
-                        <Text size="xs" c="dimmed">
-                          {`#${d.id}`}
-                        </Text>
-                      </Group>
-                    }
-                  />
-                ))}
-              </AppShell.Section>
-            </AppShell.Navbar>
+                    />
+                  ))}
+                </AppShell.Section>
+              </AppShell.Navbar>
+            )}
             <AppShell.Main pt={`calc(${rem(60)} + var(--mantine-spacing-md))`}>
               {children}
             </AppShell.Main>

--- a/packages/web/app/routes/_index/loader.ts
+++ b/packages/web/app/routes/_index/loader.ts
@@ -2,7 +2,11 @@ import type { LoaderFunction } from "@remix-run/cloudflare";
 import { fetchAwesomeYasunori } from "~/shared/fetch-awesome-yasunori";
 
 export const indexLoader = (async () => {
-  return await fetchAwesomeYasunori();
+  const data = await fetchAwesomeYasunori();
+  if (!data) {
+    throw new Response(null, { status: 404 });
+  }
+  return data;
 }) satisfies LoaderFunction;
 
 export type IndexLoader = typeof indexLoader;

--- a/packages/web/app/routes/_index/route.tsx
+++ b/packages/web/app/routes/_index/route.tsx
@@ -1,23 +1,7 @@
-import {
-  ActionIcon,
-  Avatar,
-  Card,
-  CopyButton,
-  Divider,
-  Group,
-  Paper,
-  Stack,
-  Text,
-  Title,
-  rem,
-} from "@mantine/core";
+import { Stack } from "@mantine/core";
 import type { MetaFunction } from "@remix-run/cloudflare";
 import { useLoaderData } from "@remix-run/react";
-import Markdown from "react-markdown";
-import remarkBreaks from "remark-breaks";
-import remarkGfm from "remark-gfm";
-import IconCopy from "~icons/tabler/copy";
-import IconrCopyCheckFilled from "~icons/tabler/copy-check-filled";
+import { AwesomeYasunoriCard } from "../../components/awesome-yasunori-card";
 import { type IndexLoader, indexLoader } from "./loader";
 
 export const loader = indexLoader;
@@ -29,69 +13,11 @@ export const meta: MetaFunction = () => {
 };
 
 export default function Index() {
-  const data = useLoaderData<IndexLoader>();
+  const entries = useLoaderData<IndexLoader>();
   return (
     <Stack gap="lg">
-      {data?.map((d) => (
-        <Card
-          key={d.id}
-          id={`${d.id}`}
-          shadow="sm"
-          padding="lg"
-          radius="md"
-          withBorder
-        >
-          <Card.Section p="md" component={Stack}>
-            <Title order={2} size="h2">
-              {d.title}{" "}
-              <Text c="dimmed" size="lg" span>
-                #{d.id}
-              </Text>
-            </Title>
-          </Card.Section>
-          <Card.Section>
-            <Paper p="md" style={{ position: "relative" }}>
-              <div style={{ position: "absolute", top: rem(6), right: rem(6) }}>
-                <CopyButton value={d.content}>
-                  {({ copied, copy }) => (
-                    <ActionIcon variant="subtle" color="dark" onClick={copy}>
-                      {copied ? <IconrCopyCheckFilled /> : <IconCopy />}
-                    </ActionIcon>
-                  )}
-                </CopyButton>
-              </div>
-              <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
-                {d.content}
-              </Markdown>
-            </Paper>
-          </Card.Section>
-          {d.meta && (
-            <>
-              <Card.Section px="md">
-                <Markdown remarkPlugins={[remarkBreaks, remarkGfm]}>
-                  {d.meta}
-                </Markdown>
-              </Card.Section>
-              <Card.Section>
-                <Divider />
-              </Card.Section>
-            </>
-          )}
-          <Card.Section p="md">
-            <Group gap="sm" align="center">
-              <Avatar
-                src={`https://avatars.githubusercontent.com/${d.senpan}`}
-                radius="sm"
-              />
-              <Stack gap="0">
-                <Text fw={600}>{d.senpan}</Text>
-                <Text size="sm" c="dimmed">
-                  {d.date} at {d.at}
-                </Text>
-              </Stack>
-            </Group>
-          </Card.Section>
-        </Card>
+      {entries.map((entry) => (
+        <AwesomeYasunoriCard key={entry.id} entry={entry} />
       ))}
     </Stack>
   );

--- a/packages/web/app/routes/entries.$id/loader.ts
+++ b/packages/web/app/routes/entries.$id/loader.ts
@@ -1,0 +1,24 @@
+import type { LoaderFunction } from "@remix-run/cloudflare";
+import { fetchAwesomeYasunori } from "../../shared/fetch-awesome-yasunori";
+
+export const entryLoader = (async ({ params }) => {
+  const id = Number(params.id);
+  if (Number.isNaN(id)) {
+    throw new Response(null, { status: 404 });
+  }
+
+  // TODO: APIが単体リソースを返すようになったらそれを直接取得する
+  const entries = await fetchAwesomeYasunori();
+  if (!entries) {
+    throw new Response(null, { status: 404 });
+  }
+
+  const entry = entries.find((d) => d.id === id);
+  if (!entry) {
+    throw new Response(null, { status: 404 });
+  }
+
+  return entry;
+}) satisfies LoaderFunction;
+
+export type EntryLoader = typeof entryLoader;

--- a/packages/web/app/routes/entries.$id/route.tsx
+++ b/packages/web/app/routes/entries.$id/route.tsx
@@ -1,0 +1,15 @@
+import { Flex, rem } from "@mantine/core";
+import { useLoaderData } from "@remix-run/react";
+import { AwesomeYasunoriCard } from "../../components/awesome-yasunori-card";
+import { type EntryLoader, entryLoader } from "./loader";
+
+export const loader = entryLoader;
+
+export default function Entry() {
+  const entry = useLoaderData<EntryLoader>();
+  return (
+    <Flex justify="center" align="center" mih="calc(100vh - 60px - 32px)">
+      <AwesomeYasunoriCard entry={entry} maw={rem(800)} />
+    </Flex>
+  );
+}

--- a/packages/web/app/routes/entries.$id/route.tsx
+++ b/packages/web/app/routes/entries.$id/route.tsx
@@ -9,7 +9,7 @@ export default function Entry() {
   const entry = useLoaderData<EntryLoader>();
   const navigate = useNavigate();
   return (
-    <Flex justify="center" align="center" mih="calc(100vh - 60px - 32px)">
+    <Flex justify="center" align="center" mih={`calc(100vh - ${rem(32)})`}>
       <Stack>
         <AwesomeYasunoriCard entry={entry} maw={rem(800)} />
         <Group justify="end">

--- a/packages/web/app/routes/entries.$id/route.tsx
+++ b/packages/web/app/routes/entries.$id/route.tsx
@@ -1,5 +1,5 @@
-import { Flex, rem } from "@mantine/core";
-import { useLoaderData } from "@remix-run/react";
+import { Button, Flex, Group, Stack, rem } from "@mantine/core";
+import { useLoaderData, useNavigate } from "@remix-run/react";
 import { AwesomeYasunoriCard } from "../../components/awesome-yasunori-card";
 import { type EntryLoader, entryLoader } from "./loader";
 
@@ -7,9 +7,17 @@ export const loader = entryLoader;
 
 export default function Entry() {
   const entry = useLoaderData<EntryLoader>();
+  const navigate = useNavigate();
   return (
     <Flex justify="center" align="center" mih="calc(100vh - 60px - 32px)">
-      <AwesomeYasunoriCard entry={entry} maw={rem(800)} />
+      <Stack>
+        <AwesomeYasunoriCard entry={entry} maw={rem(800)} />
+        <Group justify="end">
+          <Button variant="subtle" onClick={() => navigate("/")}>
+            Back to yasunories
+          </Button>
+        </Group>
+      </Stack>
     </Flex>
   );
 }


### PR DESCRIPTION
Close #49

URL は `/:id` だとさすがにネームスペースを汚染しすぎるかと思ったので、 `/entries/:id` にしました。 
タイトル横の `#id` をクリックすると、単体のページへと遷移できます。

単体での表示はドンと目立たせるために中央配置にしています。

<img width="1299" alt="Screenshot 2024-10-05 at 1 34 23" src="https://github.com/user-attachments/assets/ef13fd8c-3c58-44aa-a745-d33374d853b7">
