### PR TITLE
Re: runs only when related file is changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,23 @@ on:
   push:
 
 jobs:
+  changes:
+    name: Check Changes
+    runs-on: ubuntu-latest
+    outputs:
+      clojure-yasunori: ${{ steps.filter.outputs.clojure-yasunori }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: filter
+        id: filter
+        run: |
+          #!/usr/bin/env bash
+          set -euxo pipefail -o posix
+          if git diff origin/main --name-only | grep ^packages/clojure-yasunori/
+          then echo clojure-yasunori=1 >> "${GITHUB_OUTPUT}"
+          fi
   lint-github-actions:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest
@@ -128,6 +145,8 @@ jobs:
   test-clojure-yasunori:
     name: Build & Test clojure-yasunori
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ needs.changes.outputs.clojure-yasunori == '1' }}
     defaults:
       run:
         working-directory: packages/clojure-yasunori


### PR DESCRIPTION
Re: #95

---

無駄をyasunoriするのに成功した気がします（次に package/clojure-yasunori を変えたときに実際のテストはできると思います）

手元ではちゃんと動いてるのは確認できました

- main更新前（packages/clojure-yasunoriに差分がある） -> clojure-yasunoriのジョブが起動される
  https://github.com/conao3/awesome-yasunori/actions/runs/11284276463
- main更新後（packages/clojure-yasunoriに差分がない） -> clojure-yasunoriのジョブが起動されない
  https://github.com/conao3/awesome-yasunori/actions/runs/11284330435