### PR TITLE
差分チェックにpaths-filterを使う

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,16 +11,13 @@ jobs:
       clojure-yasunori: ${{ steps.filter.outputs.clojure-yasunori }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - name: filter
+        uses: dorny/paths-filter@v3
         id: filter
-        run: |
-          #!/usr/bin/env bash
-          set -euxo pipefail -o posix
-          if git diff origin/main --name-only | grep ^packages/clojure-yasunori/
-          then echo clojure-yasunori=1 >> "${GITHUB_OUTPUT}"
-          fi
+        with:
+          filters: |
+            clojure-yasunori:
+              - 'packages/clojure-yasunori/**'
   lint-github-actions:
     name: Lint GitHub Actions
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
     name: Build & Test clojure-yasunori
     runs-on: ubuntu-latest
     needs: changes
-    if: ${{ needs.changes.outputs.clojure-yasunori == '1' }}
+    if: ${{ needs.changes.outputs.clojure-yasunori == 'true' }}
     defaults:
       run:
         working-directory: packages/clojure-yasunori


### PR DESCRIPTION
CIで不要なビルドをスキップするためのCheck Changesジョブ f5af8a6e9014224cf3ffb1da29518220a21afc2b にパターンが追加しやすくなるように、[paths-filter](https://github.com/dorny/paths-filter)アクションを使います。

ちなみに、すべてのパッケージをNixでビルドできればこの差分チェック自体が不要です(#110)。