### PR TITLE
RSSアイコンをヘッダーから削除

### DIFF
--- a/packages/web/app/root.tsx
+++ b/packages/web/app/root.tsx
@@ -28,7 +28,6 @@ import "@mantine/core/styles.css";
 import { useDisclosure, useHeadroom } from "@mantine/hooks";
 import IconGitHubLogo from "~icons/tabler/brand-github";
 import IconGraph from "~icons/tabler/graph";
-import IconRSS from "~icons/tabler/rss";
 import { YasunoriSpotlight } from "./components/yasunori-spotlight";
 import { useIsMobile } from "./hooks/use-is-mobile";
 import type { IndexLoader } from "./routes/_index/loader";
@@ -113,16 +112,6 @@ export function Layout({ children }: { children: React.ReactNode }) {
                     <Group gap="sm">
                       <YasunoriSpotlight />
                       <IconGraph onClick={() => navigate("/stats")} />
-                      <ActionIcon
-                        component="a"
-                        aria-label="rss feed"
-                        href="/feed.xml"
-                        target="_blank"
-                        variant="transparent"
-                        color="gray"
-                      >
-                        <IconRSS />
-                      </ActionIcon>
                       <ActionIcon
                         component="a"
                         aria-label="GitHub Repository"


### PR DESCRIPTION
スマホ環境で段ずれが発生してしまうことを確認したので、悩んだ結果、ヘッダーからRSSアイコンを削除することにしました。

削除前
<img width="424" alt="Screenshot 2024-10-16 at 20 14 19" src="https://github.com/user-attachments/assets/20668d92-41c2-4a56-bef9-227925b36fb0">

削除後
<img width="437" alt="Screenshot 2024-10-16 at 20 14 25" src="https://github.com/user-attachments/assets/e96d8d3d-6cf2-4892-a315-af60de64b5dc">

なお、削除する判断に至った理由は次の通りです。

- `/stats` へのリンクをサイドナビなどに入れてみたが、エントリー一覧の中に、ひとつだけ他のページへのナビゲーションがあるのは違和感が強いため
- RSSが必要な人はHTMLソースを見て調べることに慣れているため
- ヘッダー左にメニューをつけるほどでもないため
