### PR TITLE
Add POST /awesome/from-slack-text

### DIFF
--- a/packages/api/src/index.test.ts
+++ b/packages/api/src/index.test.ts
@@ -118,3 +118,52 @@ describe("Test GET /awesome/random", () => {
     });
   });
 });
+
+describe("Test GET /awesome/from-slack-text", () => {
+  test("Should return 200 response", async () => {
+    const res = await app.request("/awesome/from-slack-text", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("Should return YA toml response", async () => {
+    const res = await app.request("/awesome/from-slack-text", {
+      method: "POST",
+      body: `tomoya
+  21:06
+えっ、yasunori 知らないの？
+↑
+yasuhara`,
+    });
+    const parsed = await res.text();
+    expect(parsed).toStrictEqual(`[[yasunori]]
+id = 2
+title = "えっ、yasunori 知らないの？"
+date = "2024-11-02"
+at = "vim-jp #times-yasunori"
+senpan = "tomoya"
+content = """
+えっ、yasunori 知らないの？
+↑
+yasuhara
+"""
+meta = """
+"""
+`);
+  });
+
+  test("Should return 404 error response if entry not found", async () => {
+    const res = await app.request("/awesome/0");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toStrictEqual({ errors: ["not found"] });
+  });
+
+  test("Should return 404 error response if params is not number", async () => {
+    const res = await app.request("/awesome/id");
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({
+      errors: [{ type: "safe_integer" }],
+    });
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -56,6 +56,23 @@ const route = app
     }
     return c.json(randomItem(parsedAwesomeYasunori.output.yasunori));
   })
+  .post("/awesome/from-slack-text", async (c) => {
+    if (!parsedAwesomeYasunori.success) {
+      return c.text("yasunori.toml catnot parsed", 400);
+    }
+    const slackText = await c.req.text();
+    const latestEntry = parsedAwesomeYasunori.output.yasunori.at(-1);
+    if (!latestEntry) {
+      return c.text("Cannot find next id", 400);
+    }
+    const id = latestEntry.id + 1;
+    const lines = slackText.split("\n");
+    const [senpan, , title, ...restContents] = lines;
+    const date = new Date().toISOString().split("T").at(0);
+    const content = `${title}\n${restContents.join("\n")}`;
+    const tomlString = `[[yasunori]]\nid = ${id}\ntitle = "${title}"\ndate = "${date}"\nat = "vim-jp #times-yasunori"\nsenpan = "${senpan}"\ncontent = """\n${content}\n"""\nmeta = """\n"""\n`;
+    return c.text(tomlString);
+  })
   .get("/awesome/:id", async (c) => {
     const parsedParams = getParsedRequestParams(c.req.param());
     if (!parsedParams.success) {


### PR DESCRIPTION
Close #150

下記の結果が得られるようになりました。

```sh
$ curl -X POST https://9da22547.yasunori-apis.pages.dev/awesome/from-slack-text -H 'Content-Type: text/plain' \
  --data "tomoya
  21:06
えっ、yasunori 知らないの?
↑
yasuhara"
# ここでリターン
[[yasunori]]
id = 2
title = "えっ、yasunori 知らないの?"
date = "2024-11-02"
at = "vim-jp #times-yasunori"
senpan = "tomoya"
content = """
えっ、yasunori 知らないの?
↑
yasuhara
"""
meta = """
"""
```