### PR TITLE
feat(mcp): publish mcp on pkg.pr.new

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Test
         run: pnpm test
-  lint-api-and-web:
-    name: Lint API & Web
+  lint-api-mcp-and-web:
+    name: Lint API, MCP and Web
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: publish
-        run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'
+        run: pnpm dlx pkg-pr-new publish --pnpm './packages/mcp'
 
   test-YasunoriDotNET:
     name: Build & Test Yasunori.NET

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,16 @@ jobs:
         run: pnpm run typecheck
       - name: Lint
         run: pnpm run lint
+  pkg-pr-new-for-mcp:
+    name: draft publish packages with pkg.pr.new 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: publish
+        run: pnpm dlx pkg-pr-new publish --pnpm './packages/*'
+
   test-YasunoriDotNET:
     name: Build & Test Yasunori.NET
     runs-on: ubuntu-latest

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "awesome yasunori mcp",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -10,7 +10,8 @@
     "dev": "tsx src/index.ts",
     "start": "node ./dist/index.mjs",
     "test": "vitest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepack": "npm run build && clean-pkg-json"
   },
   "keywords": [],
   "author": "",
@@ -20,6 +21,7 @@
     "@modelcontextprotocol/sdk": "^1.9.0",
     "@std/yaml": "npm:@jsr/std__yaml@^1.0.5",
     "@types/node": "^22.14.0",
+    "clean-pkg-json": "^1.2.1",
     "es-main": "^1.3.0",
     "tsdown": "^0.6.10",
     "tsx": "^4.19.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       '@types/node':
         specifier: ^22.14.0
         version: 22.14.0
+      clean-pkg-json:
+        specifier: ^1.2.1
+        version: 1.2.1
       es-main:
         specifier: ^1.3.0
         version: 1.3.0
@@ -2240,6 +2243,10 @@ packages:
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
+
+  clean-pkg-json@1.2.1:
+    resolution: {integrity: sha512-zvQBW4bCn/49SrPI3jj446QugNC3iub/9ZeFKBsCtFxxMRAlyuXTw1I5EqoOLfG1i5261Z4hKLayquHIo+/2HA==}
+    hasBin: true
 
   clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
@@ -7046,6 +7053,8 @@ snapshots:
   chownr@1.1.4: {}
 
   chownr@2.0.0: {}
+
+  clean-pkg-json@1.2.1: {}
 
   clean-stack@2.2.0: {}
 


### PR DESCRIPTION
pkg.pr.newを使ってmcpをpublishすることにしました
加えて、lintのactions名も修正しておきました

pkg-pr-newのコメントにあるpacckage名からinstallできるようになります

```
pnpx  https://pkg.pr.new/times-yasunori/awesome-yasunori/mcp@172
```