### PR TITLE
add yasunori mcp nix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
 engine-strict=true
-use-node-version=20.17.0
+use-node-version=20.19.0
 manage-package-manager-versions=true
 @jsr:registry=https://npm.jsr.io

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728492678,
-        "narHash": "sha256-9UTxR8eukdg+XZeHgxW5hQA9fIKHsKCdOIUycTryeVw=",
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5633bcff0c6162b9e4b5f1264264611e950c8ec7",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
         "type": "github"
       },
       "original": {
@@ -36,23 +36,26 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1727825735,
-        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726871744,
-        "narHash": "sha256-V5LpfdHyQkUF7RfOaDPrZDP+oqz88lTJrMT1+stXNwo=",
+        "lastModified": 1735554305,
+        "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a1d92660c6b3b7c26fb883500a80ea9d33321be2",
+        "rev": "0e82ab234249d8eee3e8c91437802b32c74bb3fd",
         "type": "github"
       },
       "original": {
@@ -90,11 +93,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1727984844,
-        "narHash": "sha256-xpRqITAoD8rHlXQafYZOLvUXCF6cnZkPfoq67ThN0Hc=",
+        "lastModified": 1743748085,
+        "narHash": "sha256-uhjnlaVTWo5iD3LXics1rp9gaKgDRQj6660+gbUU3cE=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "4446c7a6fc0775df028c5a3f6727945ba8400e64",
+        "rev": "815e4121d6a5d504c0f96e5be2dd7f871e4fd99d",
         "type": "github"
       },
       "original": {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -3,22 +3,22 @@
     final: prev:
     let
       # TODO: parse from .npmrc and package.json
-      nodeVersion = "20.17.0";
-      pnpmVersion = "9.11.0";
+      nodeVersion = "20.19.0";
+      pnpmVersion = "9.15.9";
     in
     {
       nodejs = prev.nodejs_20.overrideAttrs (oldAttrs: {
         version = nodeVersion;
         src = prev.fetchurl {
           url = "https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}.tar.xz";
-          hash = "sha256-mr8DrCM2LGA4frtjOlFjA2NxRcs8F3vjNIsWiA/Ysow=";
+          hash = "sha256-WsJRb8kFtqC8GjPnMCk36sZkqCC4h8yGvUjANfujktc=";
         };
       });
       pnpm = prev.pnpm_9.overrideAttrs (oldAttrs: {
         version = pnpmVersion;
         src = prev.fetchurl {
           url = "https://registry.npmjs.org/pnpm/-/pnpm-${pnpmVersion}.tgz";
-          hash = "sha256-HA4z9w5d+e7ehKNXvfoLH526blgZRijUihBVdW9VN1Q=";
+          hash = "sha256-z4anrXZEBjldQoam0J1zBxFyCsxtk+nc6ax6xNxKKKc=";
         };
       });
     };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -8,6 +8,7 @@
           awesome-yasunori = ../..;
         };
         yasunori-net = pkgs.callPackage ./yasunori-net { };
+        yasunori-mcp = pkgs.callPackage ./mcp { };
       };
     };
 }

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -1,0 +1,66 @@
+{
+  stdenv,
+  lib,
+  pnpm,
+  nodejs,
+}:
+let
+  baseDir = ../../../.;
+  packageJson = builtins.fromJSON (builtins.readFile (baseDir + "/packages/mcp/package.json"));
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "yasunori-${packageJson.name}";
+  version = packageJson.version;
+  src = lib.cleanSource baseDir;
+  nativeBuildInputs = [
+    pnpm.configHook
+    nodejs
+  ];
+  pnpmWorkspaces = [
+    "mcp"
+    "api"
+  ];
+  buildInputs = [ nodejs ];
+  prePnpmInstall = ''
+    pnpm config set dedupe-peer-dependents false
+  '';
+  pnpmDeps = pnpm.fetchDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      pnpmWorkspaces
+      prePnpmInstall
+      ;
+    hash = "sha256-fSjViRiTN1wr1ch6PWr/Yrs5OCt/WXVwnV3EZTh9Kdg=";
+  };
+  patchPhase = ''
+    sed -i "/use-node-version/d" .npmrc
+  '';
+  buildPhase = ''
+    runHook preBuild
+    pushd packages/api/
+    touch ./src/awesome-yasunori.json && node ./script/generate-awesome-yasunori-json.js
+    popd
+    pnpm --filter=api build
+    pnpm --filter=mcp build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{packages/mcp,packages/api,bin}
+    cp -r node_modules $out
+    cp -r packages/api/{node_modules,dist} $out/packages/api
+    cp -r packages/mcp/{node_modules,dist} $out/packages/mcp
+    ln -s $out/packages/mcp/dist/index.mjs $out/bin/yasunori-mcp
+    runHook postInstall
+  '';
+
+  meta = {
+    description = packageJson.description;
+    license = lib.licenses.isc;
+    mainProgram = "yasunori-mcp";
+  };
+})

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "deploy:api": "pnpm --filter \"@awesome-yasunori/api\" deploy",
     "deploy:web": "pnpm --filter \"@awesome-yasunori/web\" deploy"
   },
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.9",
   "devDependencies": {
     "@biomejs/biome": "1.9.3",
     "husky": "^9.1.6",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/takeokunn/awesome-yasunori.git",
   "license": "MIT",
   "type": "module",
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.9",
   "exports": {
     "./client": "./src/client.ts"
   },

--- a/packages/image-generator/package.json
+++ b/packages/image-generator/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "license": "MIT",
   "type": "module",
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "clean": "rimraf ./dist",
     "dev": "wrangler pages dev",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,7 @@
   "sideEffects": false,
   "license": "MIT",
   "type": "module",
-  "packageManager": "pnpm@9.11.0",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "build": "remix vite:build",
     "dev": "remix vite:dev --port 5184",


### PR DESCRIPTION
- yasunori mcp serverをNixでパッケージングできるようにしました。
- pnpm workspaceを扱うにあたって必要なnixpkgsの機能を使うため、flake.lockを更新しました。
  - これに伴って従来のnodeおよびpnpmのビルドが通らなくなったので更新しました。

## Summary (Generated)
This pull request includes several updates to the Node.js and pnpm versions across multiple configuration files, as well as the addition of a new package configuration for `yasunori-mcp`.

### Version Updates:
* Updated Node.js version from `20.17.0` to `20.19.0` in `.npmrc` and `nix/overlays.nix`. [[1]](diffhunk://#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deL2-R2) [[2]](diffhunk://#diff-2ad718dbee070e69c53ba853ab0fb35c49816b00d91c07bab2c024acd81a6409L6-R21)
* Updated pnpm version from `9.11.0` to `9.15.9` in `nix/overlays.nix`, `package.json`, `packages/api/package.json`, `packages/image-generator/package.json`, and `packages/web/package.json`. [[1]](diffhunk://#diff-2ad718dbee070e69c53ba853ab0fb35c49816b00d91c07bab2c024acd81a6409L6-R21) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25) [[3]](diffhunk://#diff-069a572372e4f2574eb68db90e3d6ff4d0766296abec7b3c7b0f45b098d38fcaL7-R7) [[4]](diffhunk://#diff-8a00e7c7bb89262ff813a6c499f30a349ef23f0bb6b46d57e507300875dae024L7-R7) [[5]](diffhunk://#diff-e35631c960979816b4b2bda7950788e968930fcaf2cf39b482ff23117cd13888L7-R7)

### New Package Configuration:
* Added a new package configuration for `yasunori-mcp` in `nix/packages/mcp/default.nix`.
* Included `yasunori-mcp` in the package set in `nix/packages/default.nix`.