### PR TITLE
update yasunori-mcp deps hash

### DIFF
--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -32,7 +32,7 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       prePnpmInstall
       ;
-    hash = "sha256-fSjViRiTN1wr1ch6PWr/Yrs5OCt/WXVwnV3EZTh9Kdg=";
+    hash = "sha256-AvssztEfiM6Q08cEBzrwHvii+DmexgwtOPhV9Yp12uY=";
   };
   patchPhase = ''
     sed -i "/use-node-version/d" .npmrc


### PR DESCRIPTION
マージ後にビルドが通らなかったので修正
恐らくrebaseした時に依存が更新された