### PR TITLE
improve nix flake check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,30 +36,13 @@ jobs:
         uses: actions/checkout@v4
       - name: prepare nix
         uses: cachix/install-nix-action@v29
-      - name: flake check
-        run: nix flake check
-  nix-flake-build:
-    name: Nix Flake Build
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, macos-latest ]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: checkout
-        uses: actions/checkout@v4
-      - name: prepare nix
-        uses: cachix/install-nix-action@v29
       - name: prepare cachix
         uses: cachix/cachix-action@v15
         with:
           name: times-yasunori
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      - name: build devShell
-        run: nix develop -L
-      - name: build packages
-        run: |
-          nix build -L .#yasunori-cli
-          nix build -L .#yasunori-net
+      - name: flake check
+        run: nix flake check
   lint-awesome-yasunori:
     name: Lint Awesome Yasunori
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           name: times-yasunori
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: flake check
-        run: nix flake check -L
+        run: nix flake check -L --accept-flake-config
   lint-awesome-yasunori:
     name: Lint Awesome Yasunori
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           name: times-yasunori
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - name: flake check
-        run: nix flake check
+        run: nix flake check -L
   lint-awesome-yasunori:
     name: Lint Awesome Yasunori
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,10 @@ jobs:
           ./actionlint -color
   nix-flake:
     name: Nix Flake Check
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 result
 node_modules
+.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -18,18 +34,59 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "git-hooks-nix": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1744098102,
-        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "lastModified": 1742649964,
+        "narHash": "sha256-DwOTp7nvfi8mRfuL1escHDXabVXFGT1VlPD1JHrtrco=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "dcf5072734cb576d2b0c59b2ac44f5050b5eac82",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "git-hooks-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1730768919,
+        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -51,6 +108,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1744098102,
+        "narHash": "sha256-tzCdyIJj9AjysC3OuKA+tMD/kDEDAF9mICPDU7ix0JA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c8cd81426f45942bb2906d5ed2fe21d2f19d95b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1735554305,
         "narHash": "sha256-zExSA1i/b+1NMRhGGLtNfFGXgLtgo+dcuzHzaWA6w3Q=",
         "owner": "nixos",
@@ -68,7 +141,8 @@
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs",
+        "git-hooks-nix": "git-hooks-nix",
+        "nixpkgs": "nixpkgs_2",
         "systems": "systems",
         "treefmt-nix": "treefmt-nix"
       }
@@ -90,7 +164,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1743748085,

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
           };
           treefmt = {
             projectRootFile = "flake.nix";
+            flakeCheck = false;
             programs = {
               nixfmt.enable = true;
               taplo.enable = true;

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -12,7 +12,7 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yasunori-${packageJson.name}";
   version = packageJson.version;
-  src = nix-gitignore.gitignoreSource [ "node_modules/" "*.nix" "flake.lock" ] (
+  src = nix-gitignore.gitignoreSource [ "node_modules/" "*.nix" "flake.lock" ".github" ] (
     lib.cleanSource baseDir
   );
   nativeBuildInputs = [

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -48,7 +48,7 @@ stdenv.mkDerivation (finalAttrs: {
       pnpmWorkspaces
       prePnpmInstall
       ;
-    hash = "sha256-AvssztEfiM6Q08cEBzrwHvii+DmexgwtOPhV9Yp12uY=";
+    hash = "sha256-KJX8ie6pNKy2HBPsZahBGF96otHdZJWBSUcPc803bXo=";
   };
   patchPhase = ''
     sed -i "/use-node-version/d" .npmrc

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -3,6 +3,7 @@
   lib,
   pnpm,
   nodejs,
+  nix-gitignore,
 }:
 let
   baseDir = ../../../.;
@@ -11,7 +12,9 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yasunori-${packageJson.name}";
   version = packageJson.version;
-  src = lib.cleanSource baseDir;
+  src = nix-gitignore.gitignoreSource [ "node_modules/" "*.nix" "flake.lock" ] (
+    lib.cleanSource baseDir
+  );
   nativeBuildInputs = [
     pnpm.configHook
     nodejs

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -12,9 +12,22 @@ in
 stdenv.mkDerivation (finalAttrs: {
   pname = "yasunori-${packageJson.name}";
   version = packageJson.version;
-  src = nix-gitignore.gitignoreSource [ "node_modules/" "*.nix" "flake.lock" ".github" ] (
-    lib.cleanSource baseDir
-  );
+  src = nix-gitignore.gitignoreSource [
+    "*"
+    "!yasunori.toml"
+    "!pnpm-lock.yaml"
+    "!pnpm-workspace.yaml"
+    "!packages"
+    "!packages/api"
+    "!packages/api/**"
+    "!packages/api/script/**"
+    "!packages/api/src/**"
+    "packages/api/src/awesome-yasunori.json"
+    "!packages/mcp"
+    "!packages/mcp/**"
+    "!packages/mcp/src/**"
+    "!.npmrc"
+  ] (lib.cleanSource baseDir);
   nativeBuildInputs = [
     pnpm.configHook
     nodejs

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -1,6 +1,6 @@
 {
   perSystem =
-    { pkgs, ... }:
+    { pkgs, config, ... }:
     {
       devShells = {
         default = pkgs.mkShellNoCC {
@@ -14,6 +14,10 @@
           shellHook = ''
             ${pkgs.figlet}/bin/figlet AWESOME YASUNORI
           '';
+          inputsFrom = [
+            config.pre-commit.devShell
+            config.treefmt.build.devShell
+          ];
         };
       };
     };


### PR DESCRIPTION
## 背景

Nix Packageを追加した際にCI上でのチェックが追加されておらず、マージ前のテスト漏れが発生した。

## ゴール

Nix式の側でチェック項目を定義して、チェックに漏れが発生しないようにする。
また、コミット時点でチェックが走るようにする事で、フォーマット漏れやNix式の破壊などに気付けるようにする。

## 変更内容

- git-hooks.nixを導入して、pre-commit hookで `nix flake check` を実行できるようにした
- `perSystem.check` を定義して、 `nix/` 以下のderivationをcheckできるようにした
- CIのビルドフェーズを削除して、checkのフェーズに統合した