### PR TITLE
feat(api): add /awesome/list endpoint

### DIFF
--- a/packages/api/src/index.test.ts
+++ b/packages/api/src/index.test.ts
@@ -176,3 +176,20 @@ meta = """
 `);
   });
 });
+
+describe("Test GET /awesome/list", () => {
+  test("Should return 200 response", async () => {
+    const res = await app.request("/awesome/list");
+    expect(res.status).toBe(200);
+  });
+
+  test("Should return entries list response", async () => {
+    const res = await app.request("/awesome/list");
+    const parsed = await res.json<Array<unknown>>();
+
+    expect(parsed.at(-1)).toStrictEqual({
+      id: 1,
+      title: "yasunoriの母",
+    });
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -75,6 +75,21 @@ const route = app
     const tomlString = `[[yasunori]]\nid = ${id}\ntitle = "${title}"\ndate = "${date}"\nat = "vim-jp #times-yasunori"\nsenpan = "${senpan}"\ncontent = """\n${content}\n"""\nmeta = """\n"""\n`;
     return c.text(tomlString);
   })
+  .get("/awesome/list", async (c) => {
+    if (!parsedAwesomeYasunori.success) {
+      return c.json(
+        {
+          errors: parsedAwesomeYasunori.issues,
+        },
+        400,
+      );
+    }
+
+    const entry = parsedAwesomeYasunori.output.yasunori.map(
+      ({ id, title }) => ({ id, title }),
+    );
+    return c.json(entry);
+  })
   .get("/awesome/:id", async (c) => {
     const parsedParams = getParsedRequestParams(c.req.param());
     if (!parsedParams.success) {


### PR DESCRIPTION
Introduce a new GET endpoint `/awesome/list` that returns a list of all awesome entries, containing only their `id` and `title`.

Add corresponding tests to ensure the endpoint returns a 200 status code and the expected JSON structure.

マージ後、デプロイお願いします！@tomoya
