### PR TITLE
feat: add nix hash updater for Node.js and pnpm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,3 +6,8 @@
 ## Reporting issues
 
 Please open an issue if you find anything that could be improved or have suggestions for making the list a more valuable tweet.
+
+## Development notes
+
+- If you update the Node.js or pnpm version in `package.json`, run `nix/update_sources_hash.sh` to refresh the Nix source hashes.
+    - If you don't have Nix installed, enable "Allow edits by maintainers" on your PR and we can update the hashes for you.

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -2,25 +2,16 @@
   toolchain =
     final: prev:
     let
-      # TODO: prepare prefetch script
-      packageJson = builtins.fromJSON (builtins.readFile ../package.json);
-      nodeVersion = builtins.replaceStrings [ "^" ] [ "" ] packageJson.devEngines.runtime.version;
-      pnpmVersion = builtins.replaceStrings [ "pnpm@" ] [ "" ] packageJson.packageManager;
+      sources = import ./sources.nix;
     in
     {
       nodejs = prev.nodejs_22.overrideAttrs (oldAttrs: {
-        version = nodeVersion;
-        src = prev.fetchurl {
-          url = "https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}.tar.xz";
-          hash = "sha256-Eg4PdEGQl6n6+uH9gLned5Glh+bxxIwisZMjnM0PcIQ=";
-        };
+        version = sources.pnpm.version;
+        src = prev.fetchurl sources.nodejs.src;
       });
       pnpm = prev.pnpm_9.overrideAttrs (oldAttrs: {
-        version = pnpmVersion;
-        src = prev.fetchurl {
-          url = "https://registry.npmjs.org/pnpm/-/pnpm-${pnpmVersion}.tgz";
-          hash = "sha256-hMGeeI19fuJI5Ka3FS+Ou6D0/nOApfRDyhfXbAMAUtI=";
-        };
+        version = sources.pnpm.version;
+        src = prev.fetchurl sources.pnpm.src;
       });
     };
 }

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,0 +1,22 @@
+let
+  packageJson = builtins.fromJSON (builtins.readFile ../package.json);
+  nodeVersion = builtins.replaceStrings [ "^" ] [ "" ] packageJson.devEngines.runtime.version;
+  pnpmVersion = builtins.replaceStrings [ "pnpm@" ] [ "" ] packageJson.packageManager;
+  hashes = builtins.fromTOML (builtins.readFile ./sources_hash.toml);
+in
+{
+  nodejs = {
+    version = nodeVersion;
+    src = {
+      url = "https://nodejs.org/dist/v${nodeVersion}/node-v${nodeVersion}.tar.xz";
+      hash = hashes.nodejs;
+    };
+  };
+  pnpm = {
+    version = pnpmVersion;
+    src = {
+      url = "https://registry.npmjs.org/pnpm/-/pnpm-${pnpmVersion}.tgz";
+      hash = hashes.pnpm;
+    };
+  };
+}

--- a/nix/sources_hash.toml
+++ b/nix/sources_hash.toml
@@ -1,0 +1,2 @@
+nodejs = "sha256-Eg4PdEGQl6n6+uH9gLned5Glh+bxxIwisZMjnM0PcIQ="
+pnpm = "sha256-hMGeeI19fuJI5Ka3FS+Ou6D0/nOApfRDyhfXbAMAUtI="

--- a/nix/update_sources_hash.sh
+++ b/nix/update_sources_hash.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd $(dirname ${BASH_SOURCE})
+
+NODEJS_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).nodejs.url')
+PNPM_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).pnpm.url')
+
+NODEJS_HASH=$(nix --extra-experimental-features 'flakes nix-command' hash convert --hash-algo sha256 --to sri --from nix32 $(nix-prefetch-url $NODEJS_URL))
+PNPM_HASH=$(nix --extra-experimental-features 'flakes nix-command' hash convert --hash-algo sha256 --to sri --from nix32 $(nix-prefetch-url $PNPM_URL))
+
+# Nixがそのまま読めるのとシェルから吐きやすいのでTOMLを使用している
+# 何かあってもJSONに置き換えるのは容易だと思われる
+cat > sources_hash.toml << EOF
+nodejs = "$NODEJS_HASH"
+pnpm = "$PNPM_HASH"
+EOF


### PR DESCRIPTION
`nix/overlays.nix` のハッシュ部分を分離した上でprefetchするスクリプトを加えています。
Nix使えない~~もしくは面倒臭い~~場合はこっちでスクリプト叩いてPRに加えますという文言を `CONTRIBUTING.md` に足してます。