### PR TITLE
Nixのビルド環境を修正・最新化

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1747046372,
-        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
+        "lastModified": 1761588595,
+        "narHash": "sha256-XKUZz9zewJNUj46b4AJdiRZJAvSZ0Dqj2BNfXvFlJC4=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
+        "rev": "f387cd2afec9419c8ee37694406ca490c3f34ee5",
         "type": "github"
       },
       "original": {
@@ -21,11 +21,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1756770412,
-        "narHash": "sha256-+uWLQZccFHwqpGqr2Yt5VsW/PbeJVTn9Dk6SHWhNRPw=",
+        "lastModified": 1763759067,
+        "narHash": "sha256-LlLt2Jo/gMNYAwOgdRQBrsRoOz7BPRkzvNaI/fzXi2Q=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "4524271976b625a4a605beefd893f270620fd751",
+        "rev": "2cccadc7357c0ba201788ae99c4dfa90728ef5e0",
         "type": "github"
       },
       "original": {
@@ -41,11 +41,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1757239681,
-        "narHash": "sha256-E9spYi9lxm2f1zWQLQ7xQt8Xs2nWgr1T4QM7ZjLFphM=",
+        "lastModified": 1763988335,
+        "narHash": "sha256-QlcnByMc8KBjpU37rbq5iP7Cp97HvjRP0ucfdh+M4Qc=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "ab82ab08d6bf74085bd328de2a8722c12d97bd9d",
+        "rev": "50b9238891e388c9fdc6a5c49e49c42533a1b5ce",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754340878,
-        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "lastModified": 1759417375,
+        "narHash": "sha256-O7eHcgkQXJNygY6AypkF9tFhsoDQjpNEojw3eFs73Ow=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "rev": "dc704e6102e76aad573f63b74c742cd96f8f1e6c",
         "type": "github"
       },
       "original": {
@@ -93,11 +93,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1754788789,
-        "narHash": "sha256-x2rJ+Ovzq0sCMpgfgGaaqgBSwY+LST+WbZ6TytnT9Rk=",
+        "lastModified": 1761765539,
+        "narHash": "sha256-b0yj6kfvO8ApcSE+QmA6mUfu8IYG6/uU28OFn4PaC8M=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "a73b9c743612e4244d865a2fdee11865283c04e6",
+        "rev": "719359f4562934ae99f5443f20aa06c2ffff91fc",
         "type": "github"
       },
       "original": {
@@ -108,11 +108,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1757034884,
-        "narHash": "sha256-PgLSZDBEWUHpfTRfFyklmiiLBE1i1aGCtz4eRA3POao=",
+        "lastModified": 1764167966,
+        "narHash": "sha256-nXv6xb7cq+XpjBYIjWEGTLCqQetxJu6zvVlrqHMsCOA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ca77296380960cd497a765102eeb1356eb80fed0",
+        "rev": "5c46f3bd98147c8d82366df95bbef2cab3a967ea",
         "type": "github"
       },
       "original": {
@@ -124,11 +124,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1754340878,
-        "narHash": "sha256-lgmUyVQL9tSnvvIvBp7x1euhkkCho7n3TMzgjdvgPoU=",
+        "lastModified": 1761236834,
+        "narHash": "sha256-+pthv6hrL5VLW2UqPdISGuLiUZ6SnAXdd2DdUE+fV2Q=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cab778239e705082fe97bb4990e0d24c50924c04",
+        "rev": "d5faa84122bc0a1fd5d378492efce4e289f8eac1",
         "type": "github"
       },
       "original": {
@@ -167,11 +167,11 @@
         "nixpkgs": "nixpkgs_3"
       },
       "locked": {
-        "lastModified": 1756662192,
-        "narHash": "sha256-F1oFfV51AE259I85av+MAia221XwMHCOtZCMcZLK2Jk=",
+        "lastModified": 1762938485,
+        "narHash": "sha256-AlEObg0syDl+Spi4LsZIBrjw+snSVU4T8MOeuZJUJjM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "1aabc6c05ccbcbf4a635fb7a90400e44282f61c4",
+        "rev": "5b4ee75aeefd1e2d5a1cc43cf6ba65eba75e83e4",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -17,7 +17,7 @@
     {
       _module.args.pkgs = import self.inputs.nixpkgs {
         inherit system;
-        overlays = [ self.overlays.toolchain ];
+        # overlays = [ self.overlays.toolchain ];
       };
     };
 }

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -6,7 +6,7 @@
     in
     {
       nodejs = prev.nodejs_22.overrideAttrs (oldAttrs: {
-        version = sources.pnpm.version;
+        version = sources.nodejs.version;
         src = prev.fetchurl sources.nodejs.src;
       });
       pnpm = prev.pnpm_9.overrideAttrs (oldAttrs: {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -9,7 +9,7 @@
         version = sources.nodejs.version;
         src = prev.fetchurl sources.nodejs.src;
       });
-      pnpm = prev.pnpm_9.overrideAttrs (oldAttrs: {
+      pnpm = prev.pnpm_10.overrideAttrs (oldAttrs: {
         version = sources.pnpm.version;
         src = prev.fetchurl sources.pnpm.src;
       });

--- a/nix/packages/mcp/default.nix
+++ b/nix/packages/mcp/default.nix
@@ -49,7 +49,7 @@ stdenv.mkDerivation (finalAttrs: {
       prePnpmInstall
       ;
     fetcherVersion = 2;
-    hash = "sha256-Zcmf7Px8AoadMowPauatl0x7Ema1w7uH7HECfgRYpR4=";
+    hash = "sha256-KYTK7dH8fJu44XykIwLW5LpYw7J6goK3odOz7AwUC6Q=";
   };
   buildPhase = ''
     runHook preBuild

--- a/nix/packages/yasunori-net/default.nix
+++ b/nix/packages/yasunori-net/default.nix
@@ -13,8 +13,8 @@ buildDotnetModule {
   projectFile = "Yasunori.sln";
   nugetDeps = ./deps.nix;
 
-  dotnet-sdk = dotnetCorePackages.sdk_8_0;
-  dotnet-runtime = dotnetCorePackages.runtime_8_0;
+  dotnet-sdk = dotnetCorePackages.sdk_10_0;
+  dotnet-runtime = dotnetCorePackages.runtime_10_0;
 
   # raise data race
   # System.IO.IOException: The process cannot access the file '/build/source/lib/bin/Release/net8.0/Yasunori.Net.deps.json' because it is being used by another process. [/build/source/lib/Yasunori.Net.csproj]

--- a/nix/packages/yasunori-net/default.nix
+++ b/nix/packages/yasunori-net/default.nix
@@ -13,8 +13,8 @@ buildDotnetModule {
   projectFile = "Yasunori.sln";
   nugetDeps = ./deps.nix;
 
-  dotnet-sdk = dotnetCorePackages.sdk_10_0;
-  dotnet-runtime = dotnetCorePackages.runtime_10_0;
+  dotnet-sdk = dotnetCorePackages.sdk_8_0;
+  dotnet-runtime = dotnetCorePackages.runtime_8_0;
 
   # raise data race
   # System.IO.IOException: The process cannot access the file '/build/source/lib/bin/Release/net8.0/Yasunori.Net.deps.json' because it is being used by another process. [/build/source/lib/Yasunori.Net.csproj]

--- a/nix/shells/default.nix
+++ b/nix/shells/default.nix
@@ -1,6 +1,12 @@
+{ inputs, ... }:
 {
   perSystem =
-    { pkgs, config, ... }:
+    {
+      system,
+      pkgs,
+      config,
+      ...
+    }:
     {
       devShells = {
         default = pkgs.mkShellNoCC {
@@ -8,8 +14,6 @@
             pkgs.nil
             pkgs.nodejs
             pkgs.pnpm
-
-            pkgs.dotnetCorePackages.sdk_8_0
           ];
           shellHook = ''
             ${pkgs.figlet}/bin/figlet AWESOME YASUNORI
@@ -17,6 +21,7 @@
           inputsFrom = [
             config.pre-commit.devShell
             config.treefmt.build.devShell
+            inputs.self.packages.${system}.yasunori-net
           ];
         };
       };

--- a/nix/update_sources_hash.sh
+++ b/nix/update_sources_hash.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 
 cd $(dirname ${BASH_SOURCE})
 
-NODEJS_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).nodejs.url')
-PNPM_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).pnpm.url')
+NODEJS_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).nodejs.src.url')
+PNPM_URL=$(nix --extra-experimental-features 'flakes nix-command' eval --raw --impure --expr '(import ./sources.nix).pnpm.src.url')
 
 NODEJS_HASH=$(nix --extra-experimental-features 'flakes nix-command' hash convert --hash-algo sha256 --to sri --from nix32 $(nix-prefetch-url $NODEJS_URL))
 PNPM_HASH=$(nix --extra-experimental-features 'flakes nix-command' hash convert --hash-algo sha256 --to sri --from nix32 $(nix-prefetch-url $PNPM_URL))


### PR DESCRIPTION
CIがうまく動いていないようなので、Nix周りの細かいところを直しました。

[nix-output-monitor](https://github.com/maralorn/nix-output-monitor)をインストールして、次のコマンドで依存関係を確認しながらビルドすると、どのパッケージがボトルネックになっているのかがわかりやすいです。

```sh
nix run github:Mic92/nix-fast-build -- --skip-cached \
    --flake ".#checks.$(nix eval --raw --impure --expr builtins.currentSystem)"
```